### PR TITLE
Add GitHub Actions nix flake checks (macOS + Ubuntu)

### DIFF
--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -28,5 +28,7 @@ jobs:
         uses: cachix/install-nix-action@v27
       - name: Nix flake check
         env:
-          NIX_CONFIG: experimental-features = nix-command flakes
-        run: nix flake check
+          NIX_CONFIG: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ github.token }}
+        run: nix flake check --accept-flake-config

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -1,0 +1,22 @@
+name: nix-checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  flake-check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Nix flake check
+        run: nix flake check

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -13,7 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Nix
+      - name: Install Nix (macOS)
+        if: runner.os == 'macOS'
+        uses: cachix/install-nix-action@v27
+        with:
+          install_options: --no-daemon
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Install Nix (Linux)
+        if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -15,16 +15,18 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix (macOS)
         if: runner.os == 'macOS'
-        uses: cachix/install-nix-action@v27
-        with:
-          install_options: --no-daemon
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+        run: |
+          set -euo pipefail
+          if [ -x /nix/var/nix/profiles/default/bin/nix ]; then
+            echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
+          curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm
+          echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
       - name: Install Nix (Linux)
         if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v27
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
       - name: Nix flake check
+        env:
+          NIX_CONFIG: experimental-features = nix-command flakes
         run: nix flake check

--- a/README.org
+++ b/README.org
@@ -30,6 +30,9 @@ Keyword: macOS, Xcode, Homebrew, Emacs, Zsh
   ./scripts/devcontainer-check.sh
   #+end_src
 
+** CI
+- GitHub Actions runs =nix flake check= on Ubuntu and macOS for every push and PR.
+
 ** Legacy (stow + dotnet-script)
 #+begin_src sh
 /bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/hiroakit/xcclt/HEAD/xcclt.sh)" && git clone https://github.com/hiroakit/profile --recursive && cd profile && sh install.sh

--- a/flake.nix
+++ b/flake.nix
@@ -50,10 +50,14 @@
             ./nix/darwin.nix
             home-manager.darwinModules.home-manager
             {
-              home-manager.useGlobalPkgs = true;
-              home-manager.useUserPackages = true;
-              home-manager.extraSpecialArgs = { inherit inputs hostConfig; };
-              home-manager.users.${username} = import ./nix/home.nix;
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = { inherit inputs hostConfig; };
+            home-manager.users.${username} = { ... }: {
+              imports = [ ./nix/home.nix ];
+              home.username = username;
+              home.homeDirectory = "/Users/${username}";
+            };
             }
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -62,9 +62,9 @@
       darwinConfigurations.${hostConfig.darwinHost} =
         mkDarwin hostConfig.darwinSystem;
 
-      homeConfigurations.${username}@${hostConfig.wslHost} =
+      homeConfigurations."${username}@${hostConfig.wslHost}" =
         mkHome hostConfig.wslSystem;
-      homeConfigurations.${devcontainerHost.username}@${devcontainerHost.wslHost} =
+      homeConfigurations."${devcontainerHost.username}@${devcontainerHost.wslHost}" =
         mkHomeWith { system = devcontainerHost.wslSystem; hostCfg = devcontainerHost; };
 
       checks = lib.genAttrs

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,6 +1,7 @@
-{ config, pkgs, ... }:
+{ config, pkgs, hostConfig, ... }:
 {
   system.stateVersion = 4;
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
   programs.zsh.enable = true;
+  users.users.${hostConfig.username}.home = "/Users/${hostConfig.username}";
 }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to run `nix flake check` on Ubuntu and macOS
- Document CI in README
- Stabilize macOS Nix install + flake fetching in CI

## Notes
- macOS uses Determinate Systems installer when Nix is missing
- GitHub token is passed to Nix to avoid API rate-limit fetch errors