### PR TITLE
Register SourceTree difftool and mergetool

### DIFF
--- a/resources/git/.gitconfig
+++ b/resources/git/.gitconfig
@@ -20,3 +20,9 @@
 [commit]
 	gpgsign = true
 	# template = ~/.stCommitMsg
+[difftool "sourcetree"]
+	cmd = opendiff \"$LOCAL\" \"$REMOTE\"
+	path = 
+[mergetool "sourcetree"]
+	cmd = /Applications/Sourcetree.app/Contents/Resources/opendiff-w.sh \"$LOCAL\" \"$REMOTE\" -ancestor \"$BASE\" -merge \"$MERGED\"
+	trustExitCode = true


### PR DESCRIPTION
## Summary
- Add the `difftool "sourcetree"` / `mergetool "sourcetree"` entries that SourceTree writes into `.gitconfig`, using FileMerge (`opendiff`) for diff/merge resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)