### PR TITLE
Add ~/.local/bin to PATH

### DIFF
--- a/resources/zsh/.zsh/.zshrc
+++ b/resources/zsh/.zsh/.zshrc
@@ -124,7 +124,10 @@ if [ -e $(brew --prefix)/bin/fzf ]; then
     source <(fzf --zsh)
 fi
 
+export PATH="$HOME/.local/bin:$PATH"
+
 #------------------------------------------------------------
 # Local configuration
 #------------------------------------------------------------
 [ -e ${ZDOTDIR}/.zshrc.mine ] && source ${ZDOTDIR}/.zshrc.mine
+


### PR DESCRIPTION
## Summary
- Add `~/.local/bin` to `PATH` in `.zshrc` to expose user-local binaries (e.g. the Claude Code native install under `~/.local/share/claude`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)