### PR TITLE
Set emacs as the default EDITOR

### DIFF
--- a/resources/zsh/.zsh/.zshrc
+++ b/resources/zsh/.zsh/.zshrc
@@ -85,11 +85,7 @@ source $ZSH/oh-my-zsh.sh
 # export LANG=en_US.UTF-8
 
 # Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
+# EDITOR/VISUAL は .zshenv で emacs に設定している
 
 #-------------------------------------------
 # zaw

--- a/resources/zsh/.zshenv
+++ b/resources/zsh/.zshenv
@@ -57,6 +57,32 @@ path=(
   "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"(N-/)
 )
 
+#------------------
+# Editor
+#
+# emacsを既定のエディタにする。
+# GUIを開かないように -nw (--no-window-system) を付与する。
+#------------------
+case "${OSTYPE}" in
+    darwin*)
+        emacs_bin="/Applications/Emacs.app/Contents/MacOS/Emacs"
+        ;;
+    *)
+        emacs_bin="/usr/bin/emacs"
+        ;;
+esac
+
+if [ ! -x "${emacs_bin}" ]; then
+    emacs_bin=$(command -v emacs 2>/dev/null)
+fi
+
+if [ -n "${emacs_bin}" ] && [ -x "${emacs_bin}" ]; then
+    export EDITOR="${emacs_bin} -nw"
+    export VISUAL="${EDITOR}"
+fi
+
+unset emacs_bin
+
 # node.js v12 for Azure Function Runtime
 # export PATH="/usr/local/opt/node@12/bin:$PATH"
 


### PR DESCRIPTION
Export EDITOR/VISUAL from .zshenv so every shell (including
non-interactive ones used by git and friends) opens emacs in the
terminal. The binary is resolved per OS with a `command -v` fallback,
and both variables stay unset when emacs is not installed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N9ZarFCfBv1HPv9d2cEDRG