### PR TITLE
Ignore the org-id location database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ resources/emacs/.emacs.d/transient/
 resources/emacs/.emacs.d/undohist
 resources/emacs/.emacs.d/url
 resources/emacs/.emacs.d/org-persist
+resources/emacs/.emacs.d/.org-id-locations
 hp-org-mode-local-config.el
 *.elc
 ~$*


### PR DESCRIPTION
## What

Add `resources/emacs/.emacs.d/.org-id-locations` to `.gitignore`.

## Why

`.org-id-locations` is the ID-to-file map maintained by `org-id`. Emacs regenerates and rewrites it on its own, and its contents are absolute local paths:

```
(("~/Library/Mobile Documents/com~apple~CloudDocs/neo-org/README.org" "5D5EF2BC-...")
 ("~/git/tips/emacs.org" "01957873-..." ...))
```

It differs per machine, carries no value for anyone else, and leaks the local directory layout. It was showing up as untracked noise in `git status`.

## Scope

One line in `.gitignore`. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)