### PR TITLE
Ignore every zcompdump variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ hp-org-mode-local-config.el
 .zsh_history
 resources/zsh/.zsh/.zshrc.mine
 resources/zsh/.zsh/.zsh_sessions
-resources/zsh/.zsh/.zcompdump
+resources/zsh/.zsh/.zcompdump*
 resources/zsh/.zsh/.chpwd-recent-dirs
 resources/zsh/.zcompcache
 resources/zsh/.zsh/functions/completion/_ninja


### PR DESCRIPTION
## What

Widen the `.zcompdump` entry in `.gitignore` to a prefix glob.

```diff
-resources/zsh/.zsh/.zcompdump
+resources/zsh/.zsh/.zcompdump*
```

## Why

`.zcompdump` is the completion cache `compinit` builds by digesting every completion function on `$fpath`. Current zsh names it after the host and version rather than using a bare name, and it writes a compiled `.zwc` next to it:

```
.zcompdump-MilleCrepes1-5.9
.zcompdump-MilleCrepes1-5.9.zwc
```

The existing entry matched the exact name only, so neither of those was covered and both sat in `git status` as untracked. The intent to ignore them was already there; only the pattern was out of date.

These are per-host caches that zsh regenerates on its own, so there is nothing to keep.

## Verification

`git check-ignore -v` now resolves all three to the new pattern, and `git ls-files` confirms no `zcompdump` file was ever tracked, so nothing is dropped from the index.

## Scope

One line in `.gitignore`. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)