### PR TITLE
Drop oh-my-zsh and configure zsh directly

### DIFF
--- a/resources/zsh/.zsh/.zshrc
+++ b/resources/zsh/.zsh/.zshrc
@@ -1,91 +1,118 @@
-# If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:/usr/local/bin:$PATH
+#
+# .zshrc
+#
+readonly local ZSHRC_DEBUG_MODE=0
 
-# Path to your oh-my-zsh installation.
-export ZSH="$ZDOTDIR/ohmyzsh"
+function get_this_file_path {
+  local dir
+  dir=$(dirname 0)
+  echo ${dir%/}/.zshrc
+}
+
+if [ ${ZSHRC_DEBUG_MODE} -gt 0 ]; then
+    get_this_file_path
+fi
+
+#-------------------------------------------
+# Common
+#-------------------------------------------
+setopt no_beep              # ビープ音を鳴らさない
+setopt ignore_eof           # Ctrl-D でログアウトしない
+setopt auto_cd              # ディレクトリ名の入力だけで移動する
+setopt auto_pushd           # ディレクトリ移動時、自動でディレクトリスタックに追加する
+setopt pushd_ignore_dups    # ディレクトリスタックに重複を積まない
+setopt pushd_minus          # cd -<TAB> の +/- を直感的な向きにする
+setopt magic_equal_subst    # = 以降でも補完できるようにする
+setopt interactive_comments # 対話シェルでも # 以降をコメントとして扱う
+setopt long_list_jobs       # jobs をロングフォーマットで表示する
+setopt no_flow_control      # Ctrl-S / Ctrl-Q によるフロー制御を無効にする
+autoload zed                # zsh editorを読み込む
+
+#-------------------------------------------
+# Prompt
+#-------------------------------------------
+autoload -Uz colors && colors
+setopt prompt_subst
+
+PROMPT="%{$reset_color%}%% "
+
+#-------------------------------------------
+# Colors
+#-------------------------------------------
+export LSCOLORS=exfxcxdxbxegedabagaxex
+export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30'
+
+#-------------------------------------------
+# Completion
+#-------------------------------------------
+setopt auto_list            # 補完候補を一覧表示する
+setopt auto_menu            # TABで順に補完候補を切り替える
+setopt auto_param_slash     # 補完候補がディレクトリのとき、最後にスラッシュを追加する
+setopt auto_param_keys      # カッコの対応も補完する
+setopt list_packed          # 補完候補を詰めて表示する
+setopt list_types           # 補完候補にファイルの種別も含める
+setopt no_auto_remove_slash # パスの最後に付くスラッシュを自動で削除させない
+setopt no_list_beep         # 補完候補表示時にビープ音を鳴らさせない
+setopt print_eight_bit      # 補完時の日本語を正しく表示する
+setopt always_to_end        # 補完時に文字列末尾へカーソル移動する
+setopt complete_in_word     # 単語の途中でもカーソル位置で補完する
+
+zstyle ':completion:*:default' menu select=1        # 補完候補のカーソル選択を有効にする
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}' # 補完時に大文字小文字を区別しない
+zstyle ':completion:*' list-colors 'di=34' 'ln=35' 'so=32' 'ex=31' 'bd=46;34' 'cd=43;34'
 
 # https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh
 FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+fpath=(${ZDOTDIR}/functions/completion ${fpath})
 
-# Set name of the theme to load --- if set to "random", it will
-# load a random theme each time oh-my-zsh is loaded, in which case,
-# to know which specific one was loaded, run: echo $RANDOM_THEME
-# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="hiroakit"
+autoload -Uz compinit && compinit
 
-# Set list of themes to pick from when loading at random
-# Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in $ZSH/themes/
-# If set to an empty array, this variable will have no effect.
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
+#-------------------------------------------
+# History
+#
+# HISTFILE は macOS の /etc/zshrc が ${ZDOTDIR:-$HOME}/.zsh_history に
+# 設定する。ここでも同じ式で明示しておく。${HOME} 直下を指すと
+# ZDOTDIR 側に貯めた履歴と切り離されるので注意。
+#-------------------------------------------
+HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history
+HISTSIZE=50000              # historyコマンド(メモリ上)で扱う最大件数
+SAVEHIST=100000000          # HISTFILEに保存する履歴の件数
 
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
+setopt append_history          # 履歴を追加する
+setopt extended_history        # 履歴を時刻も付けて保存する
+setopt inc_append_history      # コマンド実行の都度、履歴ファイルに保存する(標準はexit時)
+setopt hist_no_store           # historyコマンド自体は履歴に保存しない
+setopt hist_ignore_dups        # 直前と同じコマンドを履歴に追加しない
+setopt hist_ignore_all_dups    # 重複するコマンドは古い方を削除して新しい方を残す
+setopt hist_expire_dups_first  # 履歴が溢れるときは重複から先に捨てる
+setopt hist_ignore_space       # 先頭がスペースのコマンドを保存対象外にする
+setopt hist_reduce_blanks      # 余分なスペースを削除してから保存する
+setopt hist_verify             # 履歴から選んだコマンドをすぐには実行しない
+setopt share_history           # 複数のシェルで履歴を共有する
 
-# Uncomment the following line to use hyphen-insensitive completion.
-# Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
+function history-all { history -E 1 } # 全履歴を出力する(.zalias の ha が使う)
 
-# Uncomment one of the following lines to change the auto-update behavior
-# zstyle ':omz:update' mode disabled  # disable automatic updates
-# zstyle ':omz:update' mode auto      # update automatically without asking
-# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
+autoload -Uz history-search-end # 入力済みの文字列にマッチする履歴を検索する
+zle -N history-beginning-search-backward-end history-search-end
+zle -N history-beginning-search-forward-end history-search-end
 
-# Uncomment the following line to change how often to auto-update (in days).
-# zstyle ':omz:update' frequency 13
+#-------------------------------------------
+# Recent directories
+#
+# cdr でディレクトリ移動履歴を辿れるようにする。
+# zaw-cdr がこの仕組みに依存している。
+#-------------------------------------------
+autoload -Uz chpwd_recent_dirs cdr add-zsh-hook
+add-zsh-hook chpwd chpwd_recent_dirs
+zstyle ':chpwd:*' recent-dirs-max 5000
+zstyle ':chpwd:*' recent-dirs-default yes
+zstyle ':completion:*' recent-dirs-insert both
 
-# Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS="true"
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
-# You can also set it to another string to have that shown instead of the default red dots.
-# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
-# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
-# COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# You can set one of the optional three formats:
-# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# or set a custom format using the strftime function format specifications,
-# see 'man strftime' for details.
-# HIST_STAMPS="mm/dd/yyyy"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load?
-# Standard plugins can be found in $ZSH/plugins/
-# Custom plugins may be added to $ZSH_CUSTOM/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
-plugins=(git rails)
-
-source $ZSH/oh-my-zsh.sh
-
-# User configuration
-
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Preferred editor for local and remote sessions
-# EDITOR/VISUAL は .zshenv で emacs に設定している
+#-------------------------------------------
+# Aliases
+#-------------------------------------------
+[ -r ${ZDOTDIR}/.zalias ] && source ${ZDOTDIR}/.zalias
+setopt complete_aliases
 
 #-------------------------------------------
 # zaw
@@ -98,7 +125,17 @@ then
 
    zstyle ':filter-select' case-insensitive yes
    bindkey '^h'   zaw-history # コマンド履歴一覧を表示
+   bindkey '^h^h' zaw-cdr     # 素早く押すとディレクトリ移動履歴一覧を表示
+   bindkey '^@'   zaw-gitdir  # gitリポジトリ内のディレクトリ一覧を表示
 fi
+
+#-------------------------------------------
+# Key bindings
+#-------------------------------------------
+bindkey -e
+bindkey "\e[Z" reverse-menu-complete               # 補完候補表示時、Shift-Tabで逆順に移動する
+bindkey "^p" history-beginning-search-backward-end # ヒストリ検索時、Ctrl-pで戻る
+bindkey "^n" history-beginning-search-forward-end  # ヒストリ検索時、Ctrl-nで進む
 
 #-------------------------------------------
 # Claude Code command history
@@ -107,22 +144,11 @@ fi
 #-------------------------------------------
 [ -e ${ZDOTDIR}/.zclaude ] && source ${ZDOTDIR}/.zclaude
 
-
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-
+#-------------------------------------------
 # fzf
 # .zprofileに設定するとCTRL-Rがbck-i-searchのままで
 # fzfのCTRL-Rが適用されないため.zshrcに記述した
+#-------------------------------------------
 if [ -e $(brew --prefix)/bin/fzf ]; then
     source <(fzf --zsh)
 fi
@@ -133,4 +159,3 @@ export PATH="$HOME/.local/bin:$PATH"
 # Local configuration
 #------------------------------------------------------------
 [ -e ${ZDOTDIR}/.zshrc.mine ] && source ${ZDOTDIR}/.zshrc.mine
-

--- a/resources/zsh/.zsh/hiroakit.zsh-theme
+++ b/resources/zsh/.zsh/hiroakit.zsh-theme
@@ -1,5 +1,0 @@
-# Put your custom themes in this folder.
-# See: https://github.com/ohmyzsh/ohmyzsh/wiki/Customization#overriding-and-adding-themes
-#
-
-PROMPT="%{$reset_color%}%% "


### PR DESCRIPTION
## Why

oh-my-zsh was only supplying defaults, and it was not earning the slot.

- The theme it loaded, `hiroakit.zsh-theme`, is a single line: `PROMPT="%{$reset_color%}%% "`.
- Across 723 recorded commands, **not one** git or rails plugin alias was ever used. `git` was typed in full 27 times, `rails` 62 times; `gst`, `gco`, `rc`, `rs` and friends: 0.
- It accounted for 0.11s of a 0.15s shell startup.

It was also quietly holding three things broken. Switching to it in 23a6d66 dropped 179 lines of hand-tuned config, and with them:

| Broken since 23a6d66 | Symptom |
| --- | --- |
| `history-all` function | `.zalias` still aliases `ha` to it, so `ha` fails |
| `chpwd_recent_dirs` / `cdr` setup | `.chpwd-recent-dirs` sits stale; `zaw-cdr` unusable |
| `source ${ZDOTDIR}/.zalias` | **every alias in `.zalias` was dead** |

## What

Restore the settings from the pre-oh-my-zsh `.zshrc`, and keep the seven options oh-my-zsh had added on top of them (`complete_in_word`, `interactive_comments`, `long_list_jobs`, `no_flow_control`, `pushd_ignore_dups`, `pushd_minus`, `hist_expire_dups_first`).

`hiroakit.zsh-theme` is removed since only oh-my-zsh could load it. The prompt itself is unchanged.

## Verification

Interactive shells were started with and without oh-my-zsh and their state diffed.

- **`setopt`: additions only.** Every option oh-my-zsh enabled is still set, plus 15 more. Nothing regresses.
- **`SAVEHIST`: 10000 → 100000000.** oh-my-zsh had capped history retention; this restores the original value.
- **`history-all`, `cdr`, `chpwd_recent_dirs`: `MISSING` → `function`.**
- **`.zalias` aliases now load** (`ha`, `G`, `H`, `T`, `du`, `df`, …). `ls='ls -G'` and `LSCOLORS` survive, so `ls` stays coloured. Note `ll` and `la` now use the `.zalias` definitions rather than oh-my-zsh's.
- **Alias count 304 → 19**, the drop being the unused git/rails aliases.
- Startup: **0.15s → 0.08s**.

### HISTFILE

Left at `${ZDOTDIR:-$HOME}/.zsh_history`, which is what `/etc/zshrc` sets and where the live 7367-line history lives. The pre-oh-my-zsh `.zshrc` hardcoded `${HOME}/.zsh_history`; restoring that verbatim would have silently switched to a stale file last written in May 2024. Verified the active history file is unchanged after the switch.

### Pre-existing issue, not introduced here

`zsh -i -c exit` emits `can't change option: zle` twice. Bisecting shows it comes from `source <(fzf --zsh)` in a non-tty context, and it reproduces identically on the current `master`.

## Follow-up

`resources/zsh/.zsh/ohmyzsh/` (19MB, untracked) is now referenced by nothing and can be deleted once this has run for a while. Left in place for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)