### PR TITLE
Bind the zaw source menu to ^O

### DIFF
--- a/resources/zsh/.zsh/.zshrc
+++ b/resources/zsh/.zsh/.zshrc
@@ -146,7 +146,14 @@ then
    zstyle ':filter-select' case-insensitive yes
    bindkey '^h'   zaw-history # コマンド履歴一覧を表示
    bindkey '^h^h' zaw-cdr     # 素早く押すとディレクトリ移動履歴一覧を表示
-   bindkey '^@'   zaw-gitdir  # gitリポジトリ内のディレクトリ一覧を表示
+
+   # 全ソースの一覧から選ぶ。git-status や process などはここから辿る。
+   # zaw-select-src は選ばせるだけで実行しないので、zaw を割り当てる。
+   #
+   # 既定の accept-line-and-down-history を潰しているが、履歴を順に
+   # 実行し直す用途で使っていないため。^@ (Ctrl+Space) は macOS の
+   # 入力ソース切り替えと取り合いになるので避けた。
+   bindkey '^o'   zaw
 fi
 
 #-------------------------------------------


### PR DESCRIPTION
## Why

`bindkey '^@' zaw-gitdir` was restored from the pre-oh-my-zsh config in #41, but **zaw has no `gitdir` source**, so the key only reported `No such widget: zaw-gitdir`. The git-related sources it does ship are:

```
git-branches  git-files  git-log  git-recent-branches  git-reflog  git-status
```

`^h` (history) and `^h^h` (cdr) were unaffected.

## What

Bind the source menu, which reaches every source including the git ones.

```diff
-   bindkey '^@'   zaw-gitdir
+   bindkey '^o'   zaw
```

## Two things worth recording

**The widget to bind is `zaw`, not `zaw-select-src`.** `zaw-select-src` only presents the list and stores the choice in `$reply`; it never runs anything, so selecting an entry appears to do nothing. `zaw` calls it and then executes the chosen source:

```zsh
function zaw() {
    if [[ $# == 0 ]]; then
        if zle zaw-select-src; then
            func="${reply[2]}"      # take the result
    ...
    "${func}" "$@"                  # and actually run the source
```

**`^@` is not usable here.** `^@` is Ctrl+Space — the Ctrl modifier keeps the low five bits (`& 0x1F`), and both `@` (0x40) and space (0x20) collapse to 0x00. macOS claims Ctrl+Space for switching input sources, so the byte never reaches the terminal (`cat -v` shows nothing and the input source switches instead). See #20.

`^O` replaces `accept-line-and-down-history`, which re-runs history entries in sequence and is not part of this workflow. Most other control keys are already taken: fzf holds `^I`, `^R` and `^T`, and zaw holds `^H`.

## Verification

```
^o  → "^O" zaw
^h  → "^H" zaw-history          (unchanged)
^@  → "^@" set-mark-command     (back to the zsh default)
```

Menu opens, selecting a source lists its candidates, and choosing one runs the action. Leaving `^@` at its default also means it no longer competes with the input-source shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)