### PR TITLE
空行での Ctrl-D のメッセージを消す

### DIFF
--- a/resources/zsh/.zsh/.zshrc
+++ b/resources/zsh/.zsh/.zshrc
@@ -164,6 +164,24 @@ bindkey "\e[Z" reverse-menu-complete               # 補完候補表示時、Shi
 bindkey "^p" history-beginning-search-backward-end # ヒストリ検索時、Ctrl-pで戻る
 bindkey "^n" history-beginning-search-forward-end  # ヒストリ検索時、Ctrl-nで進む
 
+# 空行での Ctrl-D を握り潰す。
+#
+# ignore_eof はログアウトこそ防ぐが、代わりに毎回
+# "zsh: use 'logout' to logout." を出す。この文言だけを黙らせる
+# オプションは zsh に無いため、EOF がシェルへ届く前に ZLE 側で捨てる。
+# ignore_eof 自体は、この widget が効かない経路への保険として残す。
+#
+# 入力中の Ctrl-D は既定の delete-char-or-list に流し、
+# 前方削除と補完候補表示をそのまま使えるようにする。
+function ignore-eof-silently {
+    if [[ -n $BUFFER ]]; then
+        zle delete-char-or-list
+    fi
+    return 0
+}
+zle -N ignore-eof-silently
+bindkey "^d" ignore-eof-silently
+
 #-------------------------------------------
 # Claude Code command history
 # Claudeが実行したコマンドの履歴を検索する


### PR DESCRIPTION
## 何を直したか

空行で Ctrl-D を押すたびに `zsh: use 'logout' to logout.` が出ていたのをやめた。ログアウトしない挙動はそのまま維持する。

## なぜ

原因は `.zshrc` の `setopt ignore_eof`。ログアウトは防いでくれるが、代わりにこのメッセージを毎回出す。zsh にはこの文言だけを黙らせるオプションがないため、EOF がシェルへ届く前に ZLE 側で捨てることにした。

`ignore_eof` 自体は widget が効かない経路への保険として残している。

### 採らなかった案

- `unsetopt ignore_eof` — メッセージは消えるが Ctrl-D で実際にログアウトしてしまう。やりたいことと逆
- `bindkey -r "^d"` で単に無効化 — 入力中の前方削除と補完候補表示まで失われる

## 確認したこと

`expect` で pty を起こして検証した。修正前に `use 'logout' to` が出ることを再現したうえで、修正後に以下を確認している。

| 内容 | 結果 |
|---|---|
| 空行で Ctrl-D を4連打 | メッセージなし、シェル継続（後続の `echo` が通る） |
| 入力中の Ctrl-D | 前方削除として機能（行頭の文字を削除して実行される） |
| `exit` | 従来どおり正常終了 |

手元の実際の操作でもログアウトしないことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)