### PR TITLE
emacs コマンドが /Applications/Emacs.app を指すようにする

### DIFF
--- a/resources/zsh/.zsh/.zalias
+++ b/resources/zsh/.zsh/.zalias
@@ -24,8 +24,20 @@ case "${OSTYPE}" in
         alias ll="ls -laTopgh"
 
         alias lg="lazygit"
-        # emacsは~/.local/bin/emacs (= /Applications/Emacs.app) を指す
-        alias emacs="emacs -nw"
+        # emacsは/Applications/Emacs.appを指す。
+        #
+        # 以前は~/.local/bin/emacsのシンボリックリンク経由で参照していたが、
+        # リンクが失われるとPATH上のHomebrew版(/opt/homebrew/bin/emacs)に
+        # 黙って切り替わる。実際にそうなっていたため、絶対パスで明示する。
+        #
+        # PATHには/Applications/Emacs.app/Contents/MacOS/binも通してあるが、
+        # そこに入っているのはctags/ebrowse/emacsclient/etagsだけで、
+        # emacs本体は含まれない。PATH経由では解決できない。
+        if [ -x "/Applications/Emacs.app/Contents/MacOS/Emacs" ]; then
+            alias emacs="/Applications/Emacs.app/Contents/MacOS/Emacs -nw"
+        else
+            alias emacs="emacs -nw"
+        fi
         ;;
     linux*)
         alias su="su -l"


### PR DESCRIPTION
## 何を直したか

コマンドラインの `emacs` が `/Applications/Emacs.app` を参照するようにした。

## なぜ

`.zalias` のコメントは「emacsは~/.local/bin/emacs (= /Applications/Emacs.app) を指す」となっていたが、**その `~/.local/bin/emacs` が存在しない**。`~/.local/bin` の中身は `claude` のみ。そのため `alias emacs="emacs -nw"` は PATH 上の Homebrew 版 (`/opt/homebrew/bin/emacs`) に黙って解決されていた。

PATH には `/Applications/Emacs.app/Contents/MacOS/bin` も通してあるが、そこに入っているのは `ctags` `ebrowse` `emacsclient` `etags` の4つだけで、`emacs` 本体は1つ上の `Contents/MacOS/` にある。**PATH 経由では解決できない**。

### 採らなかった案

`~/.local/bin/emacs` のシンボリックリンクを作り直す案は採らなかった。`~/.local/bin` はリポジトリ管理外で、リンクが失われれば同じ壊れ方を繰り返すため。今回の原因がまさにそれだった。

代わりに絶対パスを直接書き、app が無い環境向けに従来の PATH 版をフォールバックとして残した。

## 確認したこと

| 内容 | 結果 |
|---|---|
| `type emacs` | `/Applications/Emacs.app/Contents/MacOS/Emacs -nw` |
| `emacs --version` | `GNU Emacs 29.3` (Emacs.app 側) |
| `-nw` での `(framep (selected-frame))` | `t` = 端末フレーム (`ns` = GUI ではない) |

`-nw` の検証は pty 上で実際に起動して行った。

## 補足

- Emacs.app は 29.3、Homebrew 版は 30.2 で、**バージョンとしては下がる**。意図した上での変更
- alias はスクリプト内では効かないため、シェルスクリプト等から呼ばれる `emacs` は引き続き Homebrew 版になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)