### PR TITLE
vterm を導入し、C-g を端末側に渡す

### DIFF
--- a/resources/emacs/.emacs.d/init.el
+++ b/resources/emacs/.emacs.d/init.el
@@ -498,10 +498,22 @@
 ;; Emacs本体が --with-modules 付きでビルドされている必要もある。
 ;;-------------------------
 
+;; vterm-keymap-exceptionsに挙げたキーはvterm-mode-mapから外され、Emacs側の
+;; コマンドが動く。ここに無いキーはvterm--self-insertとして端末へ送られる。
+;; 既定値から"C-g"だけを抜き、端末側に渡すようにした。シェルやTUIアプリの
+;; 中断にC-gを使いたいため。
+;;
+;; vterm-mode-mapはメジャーモードのキーマップなので、ミニバッファ入力中は
+;; 適用されない。プロンプトをC-gで抜ける操作はこれまで通り効く。
+;;
+;; この変数は:setでキーマップを組み直すため、setqではなくcustomize経由で
+;; 設定する必要がある。leafの:customはcustomize-set-variableを使う。
 (leaf vterm
   :ensure t
   :custom ((vterm-always-compile-module . t)
-           (vterm-max-scrollback . 10000)))
+           (vterm-max-scrollback . 10000)
+           (vterm-keymap-exceptions . '("C-c" "C-x" "C-u" "C-h" "C-l"
+                                        "M-x" "M-o" "C-y" "M-y"))))
 
 ;;-------------------------
 ;; Lisp

--- a/resources/emacs/.emacs.d/init.el
+++ b/resources/emacs/.emacs.d/init.el
@@ -482,6 +482,28 @@
 (advice-add 'deadgrep--arguments :filter-return #'deadgrep--include-args)
 
 ;;-------------------------
+;; Terminal
+;;
+;; 端末エミュレーションをCのlibvtermに任せるため、term/ansi-termより大幅に速い。
+;; これらはエミュレーションをElispでやるので出力が多いと目に見えて遅くなる。
+;; eshellやM-x shellと違い本物のTTYなので、TUIアプリもそのまま動く。
+;;
+;; モジュールのビルドにcmakeとlibvtermが要る。CMakeLists.txtの
+;; USE_SYSTEM_LIBVTERMが既定ONなので、Homebrewのlibvtermを使う。これが無いと
+;; 同梱版のビルドにフォールバックし、GNU libtool (glibtool) を要求して失敗する。
+;; macOSの/usr/bin/libtoolは同名の別物なので代用できない。
+;;
+;;   brew install cmake libvterm
+;;
+;; Emacs本体が --with-modules 付きでビルドされている必要もある。
+;;-------------------------
+
+(leaf vterm
+  :ensure t
+  :custom ((vterm-always-compile-module . t)
+           (vterm-max-scrollback . 10000)))
+
+;;-------------------------
 ;; Lisp
 ;;-------------------------
 


### PR DESCRIPTION
## 何をしたか

Emacs の端末として vterm を導入し、`C-g` を Emacs ではなく端末が受け取るようにした。

## なぜ vterm か

端末エミュレーションを C の libvterm に任せるため。`term` / `ansi-term` はこれを Elisp でやるので、出力が多いと目に見えて遅くなる。`eshell` や `M-x shell` は本物の TTY ではないため TUI アプリが動かない。

## 詰まった点

モジュールのビルドが `Compilation of 'emacs-libvterm' module succeeded` と表示しながらバイナリを生成しなかった。手動で `make` を回して原因が判明した。

```
make[3]: glibtool: No such file or directory
```

同梱の libvterm をビルドするのに GNU libtool が要るが、macOS の `/usr/bin/libtool` は同名の別物。

対処は2案あった。

- `brew install libtool` で `glibtool` を入れ、同梱版をビルドする
- **`brew install libvterm` でシステム版を使わせる** ← 採用

後者にしたのは、vterm の `CMakeLists.txt` で `USE_SYSTEM_LIBVTERM` が既定 ON だったため。本来はシステムの libvterm を使う設計で、それが無いから同梱版へフォールバックしていた。既定の意図に沿い、ビルド工程も減る。

## C-g について

`vterm-keymap-exceptions` に挙げたキーは `vterm-mode-map` から外され Emacs 側のコマンドが動く。それ以外は `vterm--self-insert` として端末へ送られる。既定では `"C-g"` が例外リストにあったため `keyboard-quit` が拾っていた。これを外した。

`setq` ではなく `customize` 経由で設定する必要がある。この変数は `:set` でキーマップを組み直すため。`leaf` の `:custom` は `customize-set-variable` を使う。

**`keyboard-quit` は失われない。** `vterm-mode-map` はメジャーモードのキーマップなのでミニバッファ入力中には適用されず、`global-map` の `C-g` は `keyboard-quit` のまま。

## 確認したこと

`*vterm*` バッファ上で `key-binding` を実際に解決させた結果。

```
buffer=*vterm* mode=vterm-mode
C-g     -> vterm--self-insert
C-a     -> vterm--self-insert
C-x C-f -> find-file
```

| 項目 | 結果 |
|---|---|
| モジュール生成 | `vterm-module.so` |
| pty 上で vterm 内のコマンド実行 | PASS |
| vterm 終了・Emacs 終了 | PASS |
| 実 init 経由の設定反映 | `vterm-max-scrollback=10000` ほか反映確認 |
| GUI Emacs での対話操作 | 確認済み |

## 前提

`--with-modules` 付きの Emacs と、`cmake` / `libvterm` が要る。init.el のコメントに残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)