### PR TITLE
native-comp の eln-cache を ignore する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ resources/emacs/.emacs.d/bookmarks
 resources/emacs/.emacs.d/custom.el
 resources/emacs/.emacs.d/dired-history
 resources/emacs/.emacs.d/el-get
+resources/emacs/.emacs.d/eln-cache
 resources/emacs/.emacs.d/elpa
 resources/emacs/.emacs.d/eshell
 resources/emacs/.emacs.d/lsp-cache


### PR DESCRIPTION
## 何をしたか

`resources/emacs/.emacs.d/eln-cache` を `.gitignore` に追加した。

## なぜ

Emacs を native-comp 有効のビルドに入れ替えたことで、実行時に `.eln` が書き出されるようになった。現時点で **27MB / 214ファイル**あり、Emacs を使うほど増え続ける。

`~/.emacs.d` はこのリポジトリの作業ツリーへのシンボリックリンクなので、放置すると `git status` が常に汚れた状態になり、マシン固有・Emacs ビルド固有のバイナリを誤ってコミットする危険がある。

同じ理由で除外済みの `elpa` の隣に置いた。

## 確認したこと

```
$ git check-ignore -v resources/emacs/.emacs.d/eln-cache/
.gitignore:9:resources/emacs/.emacs.d/eln-cache	resources/emacs/.emacs.d/eln-cache/

$ git status --short
 M .gitignore
```

追加前に `??` として出ていた `eln-cache/` が消えることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)