### PR TITLE
Add dap-mode for C++/Python debugging via lldb-dap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Emacs
 resources/emacs/.emacs.d/.cache
+resources/emacs/.emacs.d/.dap-breakpoints
 resources/emacs/.emacs.d/.lsp-session-v1
 resources/emacs/.emacs.d/auto-save-list
 resources/emacs/.emacs.d/bookmarks

--- a/resources/emacs/.emacs.d/init.el
+++ b/resources/emacs/.emacs.d/init.el
@@ -805,6 +805,33 @@
 ;;  (add-to-list 'eglot-server-programs '(python-mode "pylsp"))
   (add-hook 'c++-mode-hook 'eglot-ensure))
 
+;;------------------------------------
+;; dap-mode - デバッガー
+;;------------------------------------
+
+;; lldb-dap(Homebrew LLVM)をDAPサーバーとして使うC++/Pythonデバッガー。
+;; プロジェクト固有のデバッグ対象(プログラム・引数・環境変数)は各プロジェクトの
+;; .dir-locals.elでdap-register-debug-templateを呼んで登録する
+;; (例: proj/OpenUSD/.dir-locals.el)。ここではdap-mode自体の有効化と
+;; lldb-dapバイナリの場所だけを設定する。
+(leaf dap-mode
+  :ensure t
+  :config
+  (require 'dap-lldb)
+  ;; dap-lldb.elの provider名は "lldb-vscode" のままだが、実体は
+  ;; lldb-vscodeの後継である lldb-dap (Homebrew llvm formulaに同梱) を指す。
+  (setq dap-lldb-debug-program (list "/opt/homebrew/opt/llvm/bin/lldb-dap"))
+  (dap-mode 1)
+  (dap-ui-mode 1)
+  (define-key global-map (kbd "C-c d d") 'dap-debug)             ;; テンプレートを選んでデバッグ開始
+  (define-key global-map (kbd "C-c d b") 'dap-breakpoint-toggle) ;; ブレークポイントの設置/解除
+  (define-key global-map (kbd "C-c d q") 'dap-disconnect)        ;; デバッグセッション終了
+  ;; ステップ系はVS Code/Visual Studioと同じF5/F10/F11に寄せる(連打しやすいので).
+  (define-key global-map (kbd "<f5>") 'dap-continue)             ;; 次のブレークポイントまで実行
+  (define-key global-map (kbd "<f10>") 'dap-next)                ;; ステップオーバー
+  (define-key global-map (kbd "<f11>") 'dap-step-in)             ;; ステップイン
+  (define-key global-map (kbd "S-<f11>") 'dap-step-out))         ;; ステップアウト
+
 ;;(leaf python-mode
 ;;  :ensure t
 ;;  :hook


### PR DESCRIPTION
## Summary
- Enable dap-mode in Emacs `init.el`, using Homebrew LLVM's `lldb-dap` as the debug adapter (note: dap-lldb's internal provider/type string is still `"lldb-vscode"` even though the actual binary is lldb-dap now).
- Bindings: `C-c d b`/`C-c d d`/`C-c d q` for breakpoint-toggle/debug-start/disconnect, and `F5`/`F10`/`F11`/`S-F11` for continue/next/step-in/step-out (matches VS Code/Visual Studio, since those get pressed repeatedly during a session).
- Project-specific debug targets (program/args/env) are intentionally NOT hardcoded here — they're registered per-project via `.dir-locals.el` (e.g. `proj/OpenUSD`'s `usd-dap-debug-python`, which resolves the build/PYTHONPATH dynamically from `compile_commands.json` rather than a fixed path).
- Ignore dap-mode's local breakpoint-persistence file (`.dap-breakpoints`), a per-machine runtime artifact.

## Test plan
- [x] Verified end-to-end in GUI Emacs against a real OpenUSD debug build: set a breakpoint in `pxr/usd/pcp/primIndex.cpp` (`PcpComputePrimIndex`), started a session via `C-c d d`, breakpoint went pending (gray) → verified (green), execution stopped there with a full Python→boost::python→UsdStage→Pcp backtrace.
- [x] Verified stepping (`F10`/`F11`/`S-F11`) and continue (`F5`) work during a live session.
- [ ] `nix flake check` CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)