### PR TITLE
M-x のミニバッファを半角英数のみにする

### DIFF
--- a/resources/emacs/.emacs.d/init.el
+++ b/resources/emacs/.emacs.d/init.el
@@ -118,6 +118,45 @@
 (setq vc-follow-symlinks t)
 
 ;;-------------------------
+;; 日本語入力
+;;
+;; M-xのミニバッファでは半角英数だけを受け付けるようにする。
+;; コマンド名に日本語を打つことはないので、日本語入力が有効なまま
+;; M-xを押して入力し直す手間をなくす。
+;;
+;; 抜けたら元の状態に戻す。日本語を書いている途中でM-xを挟んでも、
+;; 戻ってきたときにそのまま書き続けられるようにするため。
+;;
+;; mac-ime-activate / mac-ime-deactivate / mac-ime-active-p は
+;; ns-inline-patchが提供する。emacs-mac版のmac-auto-ascii-modeは
+;; このビルドには無い。パッチの無い環境では何もしない。
+;;
+;; 対象をM-xに絞っているのは、find-fileやisearchでは日本語を打つため。
+;;-------------------------
+
+(defvar he-ime-active-before-minibuffer nil
+  "M-xに入る直前に日本語入力が有効だったか。")
+
+(defun he-ime-deactivate-for-execute-extended-command ()
+  "M-xのミニバッファに入るとき、日本語入力を切る。"
+  (when (and (fboundp 'mac-ime-active-p)
+             (memq this-command '(execute-extended-command
+                                  execute-extended-command-for-buffer)))
+    (setq he-ime-active-before-minibuffer (mac-ime-active-p))
+    (when he-ime-active-before-minibuffer
+      (mac-ime-deactivate))))
+
+(defun he-ime-restore-after-execute-extended-command ()
+  "M-xのミニバッファを抜けるとき、日本語入力を元に戻す。"
+  (when he-ime-active-before-minibuffer
+    (setq he-ime-active-before-minibuffer nil)
+    (when (fboundp 'mac-ime-activate)
+      (mac-ime-activate))))
+
+(add-hook 'minibuffer-setup-hook #'he-ime-deactivate-for-execute-extended-command)
+(add-hook 'minibuffer-exit-hook #'he-ime-restore-after-execute-extended-command)
+
+;;-------------------------
 ;; フレームサイズ調整
 ;;
 ;; https://m13o.net/202006052311


### PR DESCRIPTION
## 何をしたか

日本語入力が有効な状態で `M-x` を押したとき、ミニバッファが半角英数だけを受け付けるようにした。
ミニバッファを抜けたら元の入力状態に戻す。

## 半角英数に固定する理由

コマンド名に日本語を打つことはない。
日本語入力のまま `M-x` を押すと、入力モードの間違いに気付いてから打ち直すことになる。

抜けたときに元へ戻すのは、切れっぱなしにすると日本語を書いている途中に `M-x` を挟めなくなるためである。

## 実装の判断

IME の制御には `mac-ime-deactivate` を使う。
`emacs-on-apple` の `build.sh` がビルドした GNU Emacs 30.2 (`--with-ns`、ns-inline-patch 適用) で使える関数を列挙したところ、ns-inline-patch 由来の `mac-ime-activate`、`mac-ime-deactivate`、`mac-ime-active-p` があった。

同じ用途の機能として `mac-auto-ascii-mode` があるが、これは採れない。
Emacs Mac port (emacs-mac) の機能であり、GNU Emacs の NS ビルドには無いためである。
`build.sh` に configure フラグやパッチを足して有効にできるものではない。

適用範囲は `M-x` に限る。
`minibuffer-setup-hook` で `this-command` を見て、`execute-extended-command` のときだけ切る。
`find-file` や `isearch` では日本語を打つことがあるため、巻き込まない。

パッチの無い環境では何もしない。
`fboundp` で保護している。

## 確認したこと

実 init を読み込んだ状態で、フックの関数を直接呼んで検証した。

| 検証 | 結果 |
|---|---|
| フック2本の登録 | `t` |
| `this-command` が `execute-extended-command` のとき | IME `nil` (切れる) |
| ミニバッファを抜けた後 | IME `t` (元に戻る) |
| `this-command` が `find-file` のとき | IME `t` (切らない) |

GUI の Emacs でも、日本語入力を有効にしたまま `M-x` を押すと半角英数に切り替わることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
