### PR TITLE
vterm のウィンドウを下部に固定する

### DIFF
--- a/resources/emacs/.emacs.d/init.el
+++ b/resources/emacs/.emacs.d/init.el
@@ -555,6 +555,50 @@
                                         "M-x" "M-o" "C-y" "M-y"))))
 
 ;;-------------------------
+;; ウィンドウの構成
+;;
+;; treemacsを左、ソースを中央、vtermをその下に置く。
+;; vtermのウィンドウが他のバッファに奪われないようにする。
+;;
+;; display-buffer-alistは、どのバッファをどこに表示するかの規則。
+;; vtermをサイドウィンドウとして登録すると、find-fileなどの通常の表示先
+;; として選ばれなくなる。treemacsも同じ仕組みで左に出ている
+;; (treemacs-display-in-side-window)。
+;;
+;; window-sides-verticalをtにすると左右のサイドウィンドウが全高を取り、
+;; 上下は残りの幅だけを占める。nilのままだと上下が全幅を取るので、
+;; vtermがtreemacsの下まで伸びてしまう。
+;;
+;; サイドウィンドウにしただけではC-x 1 (delete-other-windows) で消える。
+;; 残すにはno-delete-other-windowsパラメータが要る。
+;;
+;; 意図的に消すときは、vtermのウィンドウでC-x 0 (delete-window)。
+;; C-x w s (window-toggle-side-windows) でも消せるが、こちらはtreemacsも
+;; 含めた全サイドウィンドウが対象になる。
+;;
+;; winner-modeはウィンドウ構成の変更を元に戻す (C-c left / C-c right)。
+;; 誤ってレイアウトを潰したときの復帰用。
+;;-------------------------
+
+(setq window-sides-vertical t)
+
+(add-to-list 'display-buffer-alist
+             '("^\\*vterm\\*"
+               (display-buffer-in-side-window)
+               (side . bottom)
+               (slot . 0)
+               (window-height . 0.3)
+               (dedicated . t)
+               (preserve-size . (nil . t))
+               (window-parameters . ((no-delete-other-windows . t)))))
+
+(leaf winner
+  :doc "Restore old window configurations"
+  :tag "builtin"
+  :require t
+  :config (winner-mode 1))
+
+;;-------------------------
 ;; Lisp
 ;;-------------------------
 


### PR DESCRIPTION
## 何をしたか

vterm を画面下部のウィンドウに固定した。
treemacs を左、ソースを中央、vterm をその下に置く配置になる。

ウィンドウ構成を元に戻す `winner-mode` も有効にした。

## vterm を固定する理由

vterm のウィンドウが `find-file` などに奪われると、そのたびに開き直すことになる。
`display-buffer-alist` でサイドウィンドウとして登録すると、通常の表示先として選ばれなくなる。
treemacs が左に出ているのも同じ仕組みである (`treemacs-display-in-side-window`)。

## 実装の判断

`window-sides-vertical` を `t` にする。
既定の `nil` では上下のサイドウィンドウがフレーム全幅を占めるため、vterm が treemacs の下まで伸びてしまう。
`t` にすると左右が全高を取り、上下は残りの幅だけを占める。

`no-delete-other-windows` パラメータを付ける。
サイドウィンドウにしただけでは `C-x 1` (`delete-other-windows`) で消える。
実際に試したところ、エラーも出さずにウィンドウ数が 2 から 1 になった。
このパラメータが無いと、固定したつもりで静かに壊れる。

意図的に消す手段は残す。
vterm のウィンドウで `C-x 0` (`delete-window`) が効くこと、バッファ自体は残ることを確認した。
`C-x w s` (`window-toggle-side-windows`) でも消せるが、こちらは treemacs も含めた全サイドウィンドウが対象になる。

## 確認したこと

実 init を読み込んだ状態で `vterm` を開いて検証した。

| 検証 | 結果 |
|---|---|
| `window-side` | `bottom` |
| `dedicated` | `t` |
| `no-delete-other-windows` | `t` |
| `C-x 1` の後も生存 | `t` |
| 他バッファに奪われた | `nil` |
| `winner-mode` | `t` (`C-c left` が `winner-undo`) |

`vterm` コマンドは `pop-to-buffer-same-window` を使うため、規則が無視される懸念があった。
`display-buffer` はアクション引数より `display-buffer-alist` を先に見るので効くはずで、実地でもそのとおりだった。

GUI の Emacs でも、treemacs が左に通しで立ち、vterm がその右側の下に出ることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
