### PR TITLE
Ignore local Codex environment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ resources/zsh/.zsh/functions/completion/_ninja
 # Python
 .python-environments
 
+# Codex
+.codex/environments/environment.toml
+
 # macOS
 *.pkg
 *.DS_Store


### PR DESCRIPTION
## Summary

- ignore the local Codex environment configuration file
- keep `.codex/environments/environment.toml` out of repository status

## Verification

- confirmed the file is matched by `git check-ignore`
- `git diff --check`