### PR TITLE
Use deadgrep from the Emacs Tools menu

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -69,6 +69,8 @@ brew "openssl@1.1"
 brew "pinentry-mac"
 # PDF rendering library (based on the xpdf-3.0 code base)
 brew "poppler"
+# Search tool like grep and The Silver Searcher
+brew "ripgrep"
 # Interpreted, interactive, object-oriented programming language
 brew "python@3.10"
 # Interpreted, interactive, object-oriented programming language

--- a/resources/emacs/.emacs.d/emacs.org
+++ b/resources/emacs/.emacs.d/emacs.org
@@ -156,6 +156,7 @@ neotree is still configured, but its role overlaps with treemacs. It will be rem
 
 deadgrep runs ripgrep. =--hidden= and =--follow= are added to the arguments, so hidden files are searched and symbolic links are followed.
 Write =.git/= in =~/.ignore= to keep the result readable.
+The Tools menu entries for grep and recursive grep also run deadgrep.
 
 #+CAPTION: Key bindings for grep
 | action | function | command | key map    |

--- a/resources/emacs/.emacs.d/init.el
+++ b/resources/emacs/.emacs.d/init.el
@@ -508,7 +508,17 @@
 
 (leaf deadgrep
   :ensure t
-  :bind ("C-x C-g" . deadgrep))  
+  :bind ("C-x C-g" . deadgrep)
+  :init
+  ;; Toolsメニューのgrepとrgrepもdeadgrepを起動する。
+  ;; deadgrepの遅延ロード前にメニューを差し替えるため:initで設定する。
+  ;; 項目の位置はそのままにし、実際に使う検索エンジンを名前にも示す。
+  (define-key global-map [menu-bar tools grep]
+              '(menu-item "Search Files (Deadgrep)..." deadgrep
+                          :help "Search files recursively with ripgrep via deadgrep"))
+  (define-key global-map [menu-bar tools rgrep]
+              '(menu-item "Recursive Search (Deadgrep)..." deadgrep
+                          :help "Search files recursively with ripgrep via deadgrep")))
 
 ;; deadgrepがripgrepに与える実行時引数を変える
 (defun deadgrep--include-args (rg-args)


### PR DESCRIPTION
## Summary

- install ripgrep through the Brewfile
- route both grep entries in the Emacs Tools menu to deadgrep
- document the Tools menu behavior

## Verification

- checked init.el parentheses and syntax with Emacs
- confirmed ripgrep 15.2.0 is installed
- ran git diff --check