### PR TITLE
Ignore the Emacs projects file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ resources/emacs/.emacs.d/eln-cache
 resources/emacs/.emacs.d/elpa
 resources/emacs/.emacs.d/eshell
 resources/emacs/.emacs.d/lsp-cache
+resources/emacs/.emacs.d/projects
 resources/emacs/.emacs.d/recentf
 resources/emacs/.emacs.d/request
 resources/emacs/.emacs.d/transient/


### PR DESCRIPTION
## Summary

- ignore the Emacs-generated projects file
- keep machine-local project state out of Git

## Verification

- confirmed resources/emacs/.emacs.d/projects is ignored with git check-ignore
- ran git diff --check
- confirmed the PR contains only the .gitignore change