### PR TITLE
Add Ghostty terminal setup

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 #+TITLE: Overview
 #+TEXT: Create: 2013-09-16
-#+TEXT: Last Update: 2026-08-05
+#+TEXT: Last Update: 2026-08-11
 #+STARTUP: showall
 #+OPTIONS: \n:t
 
@@ -50,6 +50,11 @@ Keyword: macOS, Xcode, Homebrew, Emacs, Zsh, tart
 - Records Bash commands Claude Code runs so they can be searched from zsh
   (kept in a separate file from zsh's own =$HISTFILE=, so =^R= / zaw-history stay clean).
 - See =resources/zsh/.zsh/zsh.org= for usage, key bindings, file format, and install steps.
+
+** Terminal emulator (Ghostty)
+- Install [[https://ghostty.org/][Ghostty]] through =brew/Brewfile=.
+- A truecolor-capable terminal became necessary because Apple Terminal misinterprets 24-bit RGB SGR sequences emitted by applications running in Herdr panes. In this setup, Codex diff lines had unreadable yellow backgrounds, while Ghostty rendered the same diff correctly.
+- The behavior and reproduction environment are documented in [[https://github.com/herdrdev/herdr/issues/2610][Herdr issue #2610]].
 
 ** macOS VM (tart)
 - Disposable macOS VMs, driven entirely from the CLI, for verifying changes in a clean environment.

--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -87,6 +87,8 @@ brew "tre-command"
 brew "azure/bicep/bicep"
 # Release engineering, simplified
 cask "goreleaser/tap/goreleaser"
+# Fast, native terminal emulator with truecolor support
+cask "ghostty"
 # Command-line shell and scripting language
 cask "powershell"
 vscode "azurite.azurite"


### PR DESCRIPTION
## Summary

- add Ghostty to the Homebrew bundle
- document why a truecolor-capable terminal is required for Herdr and Codex
- link the corresponding Herdr issue and reproduction details

## Why

Apple Terminal misinterprets 24-bit RGB SGR sequences emitted by applications in Herdr panes.
In a manual comparison, Codex diff lines had unreadable yellow backgrounds in Apple Terminal, while the same diff rendered correctly in Ghostty.

## Impact

Running `brew bundle --file brew/Brewfile` installs Ghostty, and the terminal choice is recorded with its technical rationale rather than as an unexplained package addition.

## Validation

- `git diff --check origin/master...HEAD`
- `brew list --cask --versions ghostty` reports Ghostty 1.3.1
- `brew bundle list --cask --file brew/Brewfile` includes `ghostty`
- manually compared the same Codex diff in Apple Terminal and Ghostty
