### PR TITLE
Configure Ghostty Japanese font

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,6 +55,7 @@ Keyword: macOS, Xcode, Homebrew, Emacs, Zsh, tart
 - Install [[https://ghostty.org/][Ghostty]] through =brew/Brewfile=.
 - A truecolor-capable terminal became necessary because Apple Terminal misinterprets 24-bit RGB SGR sequences emitted by applications running in Herdr panes. In this setup, Codex diff lines had unreadable yellow backgrounds, while Ghostty rendered the same diff correctly.
 - The behavior and reproduction environment are documented in [[https://github.com/herdrdev/herdr/issues/2610][Herdr issue #2610]].
+- The Ghostty configuration keeps its embedded font for Latin text and maps Japanese characters to =MigMix 2M=. Apply it with =darwin-rebuild switch --flake .#<darwinHost>=, then reload Ghostty with =Cmd+Shift+,=.
 
 ** macOS VM (tart)
 - Disposable macOS VMs, driven entirely from the CLI, for verifying changes in a clean environment.

--- a/nix/modules/macos.nix
+++ b/nix/modules/macos.nix
@@ -5,5 +5,7 @@
       "/opt/homebrew/bin"
       "/opt/homebrew/sbin"
     ];
+
+    xdg.configFile."ghostty/config.ghostty".source = ../../resources/ghostty/config.ghostty;
   };
 }

--- a/resources/ghostty/config.ghostty
+++ b/resources/ghostty/config.ghostty
@@ -1,0 +1,2 @@
+# Keep Ghostty's embedded font for Latin text and use MigMix 2M for Japanese.
+font-codepoint-map = U+3000-U+30FF,U+31F0-U+31FF,U+3400-U+4DBF,U+4E00-U+9FFF,U+F900-U+FAFF,U+FF00-U+FFEF=MigMix 2M


### PR DESCRIPTION
## Summary

- map Japanese Unicode ranges to MigMix 2M in Ghostty
- keep Ghostty's embedded font for Latin text
- manage the Ghostty configuration through Home Manager
- document how to apply and reload the setting

## Why

Ghostty renders Japanese with automatic fallback by default, but the selected face is not explicit or reproducible.
MigMix 2M is already installed and was previously used by this profile for Japanese terminal text, so the configuration assigns only Japanese character ranges to it without changing the Latin font.

## Impact

Applying the Home Manager configuration creates `~/.config/ghostty/config.ghostty`.
Reloading Ghostty and opening a new terminal uses MigMix 2M for Japanese characters while preserving the existing Latin appearance.

## Validation

- Ghostty 1.3.1 recognizes `MigMix 2M Regular` and `MigMix 2M Bold`
- `ghostty +validate-config --config-file=resources/ghostty/config.ghostty`
- `git diff --check origin/master...HEAD`

## Not run

- `./scripts/nix-check.sh`: `nix` is not available in the current shell environment
